### PR TITLE
Update dependencies and tidy up

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,16 +6,16 @@ edition = "2018"
 
 [dependencies]
 bustle = "0.4.1"
-tracing-subscriber = "0.2.4"
+tracing-subscriber = "0.2.11"
 num_cpus = "1.13.0"
 fxhash = "0.2.1"
 chashmap = "2.2.2"
 contrie = "0.1.4"
-flurry = "0.3.0"
-dashmap = "4.0.0-rc3"
+flurry = "0.3.1"
+dashmap = "4.0.0-rc6"
 crossbeam-epoch = "0.8"
 crossbeam-epoch-old = { package = "crossbeam-epoch", version = "0.7" }
-snmalloc-rs = "0.2.13"
+snmalloc-rs = "0.2.18"
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "conc-map-bench"
 version = "0.1.0"
 authors = ["Acrimon <joel.wejdenstal@gmail.com>"]
 edition = "2018"
+publish = false
 
 [dependencies]
 bustle = "0.4.1"

--- a/collect-data.sh
+++ b/collect-data.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-cargo bench &>> results.txt


### PR DESCRIPTION
Some minor housekeeping that would not justify multiple PRs:
  - update dependencies, most importantly upgrading Dashmap from the yanked v4.0.0-rc3;
  - add `publish = false` to the manifest to prevent accidental publication;
  - remove the presumably vestigial `collect-data.sh`